### PR TITLE
Add Schedutalk to list of projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ A list of group 8's projinda projects. Send a PR adding a short description of y
 - [Coherence](https://github.com/pqbyte/coherence) - 2D top-view multiplayer game for Android where you shoot lasers at each other ([@pqbyte](https://github.com/pqbyte), [@carllei](https://github.com/carllei))
 - [Project Broban](https://github.com/xobust/Project-Broban) - Isometric game with a random generated world and a web scoreboard ([@xobust](https://github.com/xobust/), [@willwull](https://github.com/willwull/), [@iRobsc](https://github.com/iRobsc/))
 - [Hacker News iOS](https://github.com/mictab/hacker-news-ios) - a native iOS app for reading your favorite news: Hacker News! ([@mictab](https://github.com/mictab)), ([@botronic](https://github.com/botronic))
+- [Schedutalk](https://github.com/Zalodu/Schedutalk) - Multiplatform schedule app, probably with user ratings and comments in the future. ([@zalodu](https://github.com/Zalodu/), [@EE87](https://github.com/EE87/))


### PR DESCRIPTION
I did delete the fork, just to create another one to try again, here's the new one which should be identical. There doesn't seem to be an empty line at the end though, if you think I should add that I'll have to wait until I get home to fix that. 
